### PR TITLE
Re-orders regexp to enable us of <= and >= in Basic language

### DIFF
--- a/basic-reader.rkt
+++ b/basic-reader.rkt
@@ -29,7 +29,7 @@
   (skip-whitespace in)
   (define match (if peek? regexp-match-peek regexp-try-match))
   (cond
-    ((match #rx"^(PRINT|GOTO|GOSUB|RETURN|IF|THEN|ELSE|\\*|\\+|-|/|=|<|>|<=|>=)" in)
+    ((match #rx"^(PRINT|GOTO|GOSUB|RETURN|IF|THEN|ELSE|\\*|\\+|-|/|=|<=|>=|<|>)" in)
      => (lambda (match)
           (string->symbol (bytes->string/utf-8 (car match)))))
     ((match #rx"^\\(" in)


### PR DESCRIPTION
This fixes a minor oversight. When I was using the basic-demo-syntax.rkt file I wanted it to print all the number to 100. To do this I change the last line to:
`40 IF A <= 100 THEN GOTO 20 ELSE PRINT "DONE"`
Because of the previous order in the regular expression the less-than sign matched first and caused the error `missing THEN in IF`. This fix simply moves the `<=` and `>=` before the regular `<` and `>` thus allowing the above line to function properly.